### PR TITLE
Add survey reporting and analytics dashboard

### DIFF
--- a/Backend/src/dataStore.js
+++ b/Backend/src/dataStore.js
@@ -1,0 +1,5 @@
+const missions = new Map();
+const drones = new Map();
+const reports = new Map();
+
+module.exports = { missions, drones, reports };

--- a/Backend/src/routes/drones.js
+++ b/Backend/src/routes/drones.js
@@ -1,9 +1,9 @@
 const express = require('express');
 const { v4: uuidv4 } = require('uuid');
+const { drones } = require('../dataStore');
 
 function createDronesRouter(io) {
   const router = express.Router();
-  const drones = new Map();
   const validStatuses = ['available', 'charging', 'in_mission', 'maintenance'];
 
   // Register a new drone

--- a/Backend/src/routes/missions.js
+++ b/Backend/src/routes/missions.js
@@ -1,10 +1,10 @@
 const express = require('express');
 const { v4: uuidv4 } = require('uuid');
+const { missions, reports } = require('../dataStore');
 
 // Create a router factory so we can emit WebSocket events
 function createMissionsRouter(io) {
   const router = express.Router();
-  const missions = new Map();
 
   // Create a new mission
   router.post('/', (req, res) => {
@@ -104,6 +104,16 @@ function createMissionsRouter(io) {
     if (mission.completedWaypoints >= mission.waypoints.length) {
       mission.status = 'completed';
       mission.eta = 0;
+      const report = {
+        mission_id: mission.id,
+        duration: mission.startTime
+          ? (Date.now() - mission.startTime) / 1000
+          : 0,
+        distance: mission.distanceTraveled,
+        coverage: mission.waypoints.length,
+        created_at: new Date().toISOString()
+      };
+      reports.set(mission.id, report);
       io.emit(`mission/${mission.id}/events`, {
         status: mission.status,
         progress: 1,

--- a/Backend/src/routes/reports.js
+++ b/Backend/src/routes/reports.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const { missions, drones, reports } = require('../dataStore');
+
+const router = express.Router();
+
+// Per-mission summary
+router.get('/missions/:id', (req, res) => {
+  const mission = missions.get(req.params.id);
+  if (!mission) return res.status(404).json({ error: 'Mission not found' });
+  const report = reports.get(req.params.id);
+  if (!report) return res.status(404).json({ error: 'Report not available' });
+  const summary = {
+    mission_id: report.mission_id,
+    duration: report.duration,
+    distance: report.distance,
+    waypoints: mission.waypoints.length,
+    created_at: report.created_at
+  };
+  res.json(summary);
+});
+
+// Org-wide analytics
+router.get('/org', (_req, res) => {
+  const totalMissions = missions.size;
+  const completed = Array.from(missions.values()).filter(m => m.status === 'completed').length;
+  const dronesArr = Array.from(drones.values());
+  const averageBattery = dronesArr.length
+    ? dronesArr.reduce((sum, d) => sum + d.battery, 0) / dronesArr.length
+    : 0;
+  const missionSuccessRate = totalMissions ? completed / totalMissions : 0;
+  res.json({ totalMissions, averageBattery, missionSuccessRate });
+});
+
+module.exports = router;

--- a/Backend/src/server.js
+++ b/Backend/src/server.js
@@ -18,16 +18,11 @@ app.use(express.json());
 
 const createMissionsRouter = require('./routes/missions');
 const createDronesRouter = require('./routes/drones');
+const reportsRouter = require('./routes/reports');
 
 app.use('/missions', createMissionsRouter(io));
 app.use('/drones', createDronesRouter(io));
-
-
-const missionsRouter = require('./routes/missions');
-
-
-app.use('/missions', missionsRouter);
-app.use('/drones', createDronesRouter(io));
+app.use('/reports', reportsRouter);
 
 
 

--- a/frontend/src/AnalyticsDashboard.js
+++ b/frontend/src/AnalyticsDashboard.js
@@ -1,0 +1,84 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+function AnalyticsDashboard() {
+  const [orgStats, setOrgStats] = useState(null);
+  const chartRef = useRef(null);
+  const [missionId, setMissionId] = useState('');
+  const [missionSummary, setMissionSummary] = useState(null);
+
+  useEffect(() => {
+    fetch('http://localhost:5001/reports/org')
+      .then((res) => res.json())
+      .then(setOrgStats)
+      .catch(console.error);
+  }, []);
+
+  useEffect(() => {
+    if (!orgStats) return;
+    if (!window.Chart) {
+      const script = document.createElement('script');
+      script.src = 'https://cdn.jsdelivr.net/npm/chart.js';
+      script.onload = () => drawChart(orgStats);
+      document.body.appendChild(script);
+    } else {
+      drawChart(orgStats);
+    }
+  }, [orgStats]);
+
+  function drawChart(stats) {
+    const ctx = chartRef.current.getContext('2d');
+    new window.Chart(ctx, {
+      type: 'doughnut',
+      data: {
+        labels: ['Success', 'Failure'],
+        datasets: [
+          {
+            data: [stats.missionSuccessRate * 100, 100 - stats.missionSuccessRate * 100],
+            backgroundColor: ['#36A2EB', '#FF6384'],
+          },
+        ],
+      },
+      options: { responsive: false },
+    });
+  }
+
+  if (!orgStats) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div>
+      <h2>Org-wide Analytics</h2>
+      <p>Total Missions: {orgStats.totalMissions}</p>
+      <p>Average Battery: {orgStats.averageBattery.toFixed(2)}%</p>
+      <canvas ref={chartRef} width="300" height="200"></canvas>
+      <div style={{ marginTop: '1rem' }}>
+        <h3>Per-Mission Summary</h3>
+        <input
+          value={missionId}
+          onChange={(e) => setMissionId(e.target.value)}
+          placeholder="Mission ID"
+        />
+        <button
+          onClick={() => {
+            fetch(`http://localhost:5001/reports/missions/${missionId}`)
+              .then((res) => res.json())
+              .then(setMissionSummary)
+              .catch(() => setMissionSummary(null));
+          }}
+        >
+          Load
+        </button>
+        {missionSummary && (
+          <ul>
+            <li>Duration: {missionSummary.duration}s</li>
+            <li>Distance: {missionSummary.distance.toFixed(2)}m</li>
+            <li>Waypoints: {missionSummary.waypoints}</li>
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default AnalyticsDashboard;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,23 +1,10 @@
-import logo from './logo.svg';
 import './App.css';
+import AnalyticsDashboard from './AnalyticsDashboard';
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <AnalyticsDashboard />
     </div>
   );
 }

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders analytics header', async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () =>
+        Promise.resolve({
+          totalMissions: 1,
+          averageBattery: 50,
+          missionSuccessRate: 1,
+        }),
+    })
+  );
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const header = await screen.findByText(/Org-wide Analytics/i);
+  expect(header).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- track missions and drones in shared data store
- generate survey reports and org-wide analytics endpoints
- add React dashboard with Chart.js visualization and mission summary lookup

## Testing
- `npm test --prefix Backend`
- `npm test --prefix frontend -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68964d9a32148324b53bbd10de76b252