### PR TITLE
Proxy frontend to backend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "proxy": "http://localhost:5001",
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/frontend/src/AnalyticsDashboard.js
+++ b/frontend/src/AnalyticsDashboard.js
@@ -7,7 +7,7 @@ function AnalyticsDashboard() {
   const [missionSummary, setMissionSummary] = useState(null);
 
   useEffect(() => {
-    fetch('http://localhost:5001/reports/org')
+    fetch('/reports/org')
       .then((res) => res.json())
       .then(setOrgStats)
       .catch(console.error);
@@ -61,7 +61,7 @@ function AnalyticsDashboard() {
         />
         <button
           onClick={() => {
-            fetch(`http://localhost:5001/reports/missions/${missionId}`)
+            fetch(`/reports/missions/${missionId}`)
               .then((res) => res.json())
               .then(setMissionSummary)
               .catch(() => setMissionSummary(null));


### PR DESCRIPTION
## Summary
- proxy frontend API requests to backend server
- switch analytics dashboard fetches to relative paths

## Testing
- `npm --prefix Backend test`
- `npm --prefix frontend test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68965599ae688324834c477daedfa5d5