### PR TITLE
Fix JSON response handling for analytics dashboard

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:5001",
   "dependencies": {
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.4",
@@ -17,8 +18,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject",
-    "proxy": "http://localhost:5001"
+    "eject": "react-scripts eject"
   },
   "eslintConfig": {
     "extends": [

--- a/frontend/src/AnalyticsDashboard.js
+++ b/frontend/src/AnalyticsDashboard.js
@@ -6,9 +6,18 @@ function AnalyticsDashboard() {
   const [missionId, setMissionId] = useState('');
   const [missionSummary, setMissionSummary] = useState(null);
 
+  const fetchJson = (url) =>
+    fetch(url).then(async (res) => {
+      if (!res.ok) throw new Error(`Request failed with ${res.status}`);
+      const contentType = res.headers.get('content-type') || '';
+      if (!contentType.includes('application/json')) {
+        throw new Error(`Expected JSON but received ${contentType}`);
+      }
+      return res.json();
+    });
+
   useEffect(() => {
-    fetch('/reports/org')
-      .then((res) => res.json())
+    fetchJson('/reports/org')
       .then(setOrgStats)
       .catch(console.error);
   }, []);
@@ -61,8 +70,7 @@ function AnalyticsDashboard() {
         />
         <button
           onClick={() => {
-            fetch(`/reports/missions/${missionId}`)
-              .then((res) => res.json())
+            fetchJson(`/reports/missions/${missionId}`)
               .then(setMissionSummary)
               .catch(() => setMissionSummary(null));
           }}

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -4,6 +4,8 @@ import App from './App';
 test('renders analytics header', async () => {
   global.fetch = jest.fn(() =>
     Promise.resolve({
+      ok: true,
+      headers: { get: () => 'application/json' },
       json: () =>
         Promise.resolve({
           totalMissions: 1,


### PR DESCRIPTION
## Summary
- configure React proxy to forward API requests to backend
- validate fetch responses before parsing JSON in AnalyticsDashboard
- update unit test to mock full fetch response

## Testing
- `npm test` (backend)
- `CI=true npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68965802e60c8324abb6f5b22b8182c6