### PR TITLE
Handle Chart.js load errors

### DIFF
--- a/frontend/src/AnalyticsDashboard.js
+++ b/frontend/src/AnalyticsDashboard.js
@@ -27,7 +27,17 @@ function AnalyticsDashboard() {
     if (!window.Chart) {
       const script = document.createElement('script');
       script.src = 'https://cdn.jsdelivr.net/npm/chart.js';
-      script.onload = () => drawChart(orgStats);
+      script.crossOrigin = 'anonymous';
+      script.onload = () => {
+        try {
+          drawChart(orgStats);
+        } catch (err) {
+          console.error('Error rendering chart', err);
+        }
+      };
+      script.onerror = (err) => {
+        console.error('Failed to load Chart.js', err);
+      };
       document.body.appendChild(script);
     } else {
       drawChart(orgStats);


### PR DESCRIPTION
## Summary
- prevent generic "Script error" by loading Chart.js with `crossOrigin` and explicit error handling

## Testing
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68965af13d008324915ac31ba8fafeb2