### PR TITLE
Handle object coordinate input for missions

### DIFF
--- a/Backend/src/routes/missions.js
+++ b/Backend/src/routes/missions.js
@@ -158,7 +158,11 @@ function createMissionsRouter(io) {
 // Generate waypoints based on pattern
 function generateWaypoints(coords, altitude, pattern, overlap) {
   const spacing = overlap || 0.001; // degree spacing for demo
-  const polygon = coords.map(([lng, lat]) => ({ lng, lat }));
+  // Allow coordinates to be provided either as [lng, lat] arrays
+  // or as objects of the form { lat, lng }
+  const polygon = coords.map((pt) =>
+    Array.isArray(pt) ? { lng: pt[0], lat: pt[1] } : { lng: pt.lng, lat: pt.lat }
+  );
   if (
     polygon[0].lng !== polygon[polygon.length - 1].lng ||
     polygon[0].lat !== polygon[polygon.length - 1].lat


### PR DESCRIPTION
## Summary
- Allow mission coordinates to be provided as either `[lng, lat]` arrays or `{ lat, lng }` objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896d050d9188324b6fdb0f16f5ef3e3