### PR TITLE
Fix mission coordinate parsing and Chart.js canvas reuse

### DIFF
--- a/frontend/src/AnalyticsDashboard.js
+++ b/frontend/src/AnalyticsDashboard.js
@@ -3,6 +3,10 @@ import React, { useEffect, useRef, useState } from 'react';
 function AnalyticsDashboard() {
   const [orgStats, setOrgStats] = useState(null);
   const chartRef = useRef(null);
+  // Keep a reference to the current Chart.js instance so we can
+  // destroy it before creating a new one. This avoids the
+  // "Canvas is already in use" error when the component rerenders.
+  const chartInstanceRef = useRef(null);
   const [missionId, setMissionId] = useState('');
   const [missionSummary, setMissionSummary] = useState(null);
 
@@ -42,11 +46,20 @@ function AnalyticsDashboard() {
     } else {
       drawChart(orgStats);
     }
+    return () => {
+      if (chartInstanceRef.current) {
+        chartInstanceRef.current.destroy();
+        chartInstanceRef.current = null;
+      }
+    };
   }, [orgStats]);
 
   function drawChart(stats) {
     const ctx = chartRef.current.getContext('2d');
-    new window.Chart(ctx, {
+    if (chartInstanceRef.current) {
+      chartInstanceRef.current.destroy();
+    }
+    chartInstanceRef.current = new window.Chart(ctx, {
       type: 'doughnut',
       data: {
         labels: ['Success', 'Failure'],


### PR DESCRIPTION
## Summary
- Support multiple polygon coordinate formats when generating mission waypoints
- Normalize and validate mission coordinates before waypoint generation
- Destroy existing Chart.js instance before drawing new analytics chart

## Testing
- `npm test` (backend)
- `npm test -- --watchAll=false` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6896e87fb7a88324b9e255cd83e56fb8