### PR TITLE
Gracefully handle invalid segments in waypoint generation

### DIFF
--- a/Backend/src/routes/missions.js
+++ b/Backend/src/routes/missions.js
@@ -203,7 +203,19 @@ function generateWaypoints(coords, altitude, pattern, overlap) {
   if (pattern === 'grid' || pattern === 'crosshatch') {
     for (let y = minLat; y <= maxLat; y += spacing) {
       const segments = horizontalIntersections(polygon, y);
-      segments.forEach(([startLng, endLng]) => {
+      segments.forEach((seg) => {
+        // Each segment is expected to be an iterable pair [startLng, endLng].
+        // In case an object or invalid value sneaks in, coerce it into a
+        // two-number array and skip anything we can't interpret. This avoids
+        // "object is not iterable" errors when destructuring.
+        const pair = Array.isArray(seg)
+          ? seg
+          : seg && typeof seg === 'object'
+          ? [seg[0] ?? seg.startLng, seg[1] ?? seg.endLng]
+          : [];
+        const [startLng, endLng] = pair;
+        if (typeof startLng !== 'number' || typeof endLng !== 'number') return;
+
         if (lineCount % 2 === 0) {
           points.push({ lat: y, lng: startLng, altitude });
           points.push({ lat: y, lng: endLng, altitude });
@@ -219,7 +231,14 @@ function generateWaypoints(coords, altitude, pattern, overlap) {
   if (pattern === 'crosshatch') {
     for (let x = minLng; x <= maxLng; x += spacing) {
       const segments = verticalIntersections(polygon, x);
-      segments.forEach(([startLat, endLat]) => {
+      segments.forEach((seg) => {
+        const pair = Array.isArray(seg)
+          ? seg
+          : seg && typeof seg === 'object'
+          ? [seg[0] ?? seg.startLat, seg[1] ?? seg.endLat]
+          : [];
+        const [startLat, endLat] = pair;
+        if (typeof startLat !== 'number' || typeof endLat !== 'number') return;
         points.push({ lat: startLat, lng: x, altitude });
         points.push({ lat: endLat, lng: x, altitude });
       });


### PR DESCRIPTION
## Summary
- prevent `object is not iterable` errors when building grid/crosshatch mission paths

## Testing
- `npm test`
- `node src/server.js &` then `curl -X POST http://localhost:5001/missions ...`


------
https://chatgpt.com/codex/tasks/task_e_6896ea8c5ab88324b0cd53511ef6bb6d