### PR TITLE
Add mission creation broadcast and listing endpoint

### DIFF
--- a/Backend/src/routes/missions.js
+++ b/Backend/src/routes/missions.js
@@ -67,7 +67,14 @@ function createMissionsRouter(io) {
     };
 
     missions.set(id, mission);
+    io.emit('mission-created', mission);
+    console.log('Mission created', id);
     res.status(201).json(mission);
+  });
+
+  // List all missions
+  router.get('/', (_req, res) => {
+    res.json(Array.from(missions.values()));
   });
 
   // Retrieve mission details


### PR DESCRIPTION
## Summary
- Emit `mission-created` WebSocket event and log when new missions are created
- Provide `GET /missions` endpoint to list all missions

## Testing
- `cd Backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896f65189a48324b0e4ec165274ec69