### PR TITLE
Track mission start and end times

### DIFF
--- a/Backend/src/routes/reports.js
+++ b/Backend/src/routes/reports.js
@@ -24,7 +24,9 @@ router.get('/missions/:id', (req, res) => {
     // If the mission has been purged fall back to the coverage value stored in
     // the report itself.
     waypoints: mission ? mission.waypoints.length : report.coverage,
-    created_at: report.created_at
+    created_at: report.created_at,
+    start_time: report.start_time,
+    end_time: report.end_time
   };
   res.json(summary);
 });


### PR DESCRIPTION
## Summary
- add `endTime` field to mission data
- include mission `start_time` and `end_time` in generated reports
- expose report timestamps via `/reports/missions/:id`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68970b9d34d4832495f06c71a82a463a