### PR TITLE
feat: allow configurable backend URL

### DIFF
--- a/frontend/src/AnalyticsDashboard.js
+++ b/frontend/src/AnalyticsDashboard.js
@@ -1,5 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
 
+// Allow the backend API base URL to be configured at build time.  When the
+// frontend is served from a different origin than the backend (e.g. the React
+// dev server on port 3000 proxying to an API on port 5001) we need to prefix
+// all requests with the backend host.  In production the variable can be left
+// unset so that relative URLs continue to work when both services share the
+// same origin.
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '';
+
 function AnalyticsDashboard() {
   const [orgStats, setOrgStats] = useState(null);
   const chartRef = useRef(null);
@@ -12,7 +20,7 @@ function AnalyticsDashboard() {
   const [missionError, setMissionError] = useState(null);
 
   const fetchJson = (url) =>
-    fetch(url).then(async (res) => {
+    fetch(`${API_BASE_URL}${url}`).then(async (res) => {
       const contentType = res.headers.get('content-type') || '';
       const isJson = contentType.includes('application/json');
       const data = isJson ? await res.json() : null;


### PR DESCRIPTION
## Summary
- allow specifying backend API host via `REACT_APP_API_BASE_URL`
- prefix analytics dashboard requests with the configured base URL

## Testing
- `npm test` (backend)
- `CI=true npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68977f6ce0e48324903206a07e741b32