### PR TITLE
Expose planned mission distance and duration

### DIFF
--- a/Backend/src/routes/reports.js
+++ b/Backend/src/routes/reports.js
@@ -40,8 +40,11 @@ router.get('/missions/:id', (req, res) => {
   // especially useful for missions that are planned or in progress.
   const summary = {
     mission_id: mission.id,
-    duration: null,
-    distance: mission.distanceTraveled || 0,
+    duration:
+      mission.startTime && mission.endTime
+        ? (mission.endTime - mission.startTime) / 1000
+        : null,
+    distance: mission.totalDistance || mission.distanceTraveled || 0,
     waypoints: mission.waypoints ? mission.waypoints.length : 0,
     created_at: null,
     start_time: mission.startTime ? new Date(mission.startTime).toISOString() : null,


### PR DESCRIPTION
## Summary
- Return planned duration and total distance for missions without reports so pre-mission summaries show expected values

## Testing
- `npm test`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689794d8c8148324a04efaab0c77d8e9