### PR TITLE
Poll org stats for live chart updates

### DIFF
--- a/frontend/src/AnalyticsDashboard.js
+++ b/frontend/src/AnalyticsDashboard.js
@@ -35,9 +35,29 @@ function AnalyticsDashboard() {
     });
 
   useEffect(() => {
-    fetchJson('/reports/org')
-      .then(setOrgStats)
-      .catch(console.error);
+    let isCancelled = false;
+
+    const load = () => {
+      fetchJson('/reports/org')
+        .then((stats) => {
+          if (!isCancelled) {
+            setOrgStats(stats);
+          }
+        })
+        .catch((err) => {
+          if (!isCancelled) {
+            console.error(err);
+          }
+        });
+    };
+
+    load();
+    const intervalId = setInterval(load, 5000);
+
+    return () => {
+      isCancelled = true;
+      clearInterval(intervalId);
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- poll `/reports/org` every 5 seconds so analytics chart shows fresh data
- cleanly tear down poller on unmount

## Testing
- `cd frontend && npm test -- --watchAll=false`
- `cd ../Backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897a0e01fb88324aa35140c1307953e