### PR TITLE
Add failure reason analytics to mission dashboard

### DIFF
--- a/Backend/src/routes/missions.js
+++ b/Backend/src/routes/missions.js
@@ -71,7 +71,8 @@ function createMissionsRouter(io) {
       startTime: start,
       endTime: start + duration * 1000,
       progress: 0,
-      eta: duration
+      eta: duration,
+      failureReason: null
     };
 
     missions.set(id, mission);
@@ -126,6 +127,9 @@ function createMissionsRouter(io) {
         };
         reports.set(mission.id, report);
       }
+    } else if (mission.status === 'failed') {
+      mission.endTime = mission.endTime || Date.now();
+      mission.eta = null;
     }
 
     io.emit(`mission/${mission.id}/events`, {

--- a/Backend/src/routes/reports.js
+++ b/Backend/src/routes/reports.js
@@ -55,14 +55,30 @@ router.get('/missions/:id', (req, res) => {
 
 // Org-wide analytics
 router.get('/org', (_req, res) => {
-  const totalMissions = missions.size;
-  const completed = Array.from(missions.values()).filter(m => m.status === 'completed').length;
+  const allMissions = Array.from(missions.values());
+  const totalMissions = allMissions.length;
+  const successes = allMissions.filter(m => m.status === 'completed').length;
+  const batteryFailures = allMissions.filter(
+    m => m.status === 'failed' && m.failureReason === 'battery'
+  ).length;
+  const damageFailures = allMissions.filter(
+    m => m.status === 'failed' && m.failureReason === 'damage'
+  ).length;
   const dronesArr = Array.from(drones.values());
   const averageBattery = dronesArr.length
     ? dronesArr.reduce((sum, d) => sum + d.battery, 0) / dronesArr.length
     : 0;
-  const missionSuccessRate = totalMissions ? completed / totalMissions : 0;
-  res.json({ totalMissions, averageBattery, missionSuccessRate });
+  const missionSuccessRate = totalMissions ? successes / totalMissions : 0;
+  res.json({
+    totalMissions,
+    averageBattery,
+    missionSuccessRate,
+    missionOutcomes: {
+      success: successes,
+      batteryFailure: batteryFailures,
+      damageFailure: damageFailures
+    }
+  });
 });
 
 module.exports = router;

--- a/frontend/src/AnalyticsDashboard.js
+++ b/frontend/src/AnalyticsDashboard.js
@@ -89,9 +89,21 @@ function AnalyticsDashboard() {
   }, [orgStats]);
 
   function drawChart(stats) {
-    const data = [stats.missionSuccessRate * 100, 100 - stats.missionSuccessRate * 100];
+    const outcomes = stats.missionOutcomes || {
+      success: 0,
+      batteryFailure: 0,
+      damageFailure: 0,
+    };
+    const data = [
+      outcomes.success,
+      outcomes.batteryFailure,
+      outcomes.damageFailure,
+    ];
+    const labels = ['Success', 'Battery Failure', 'Damage Failure'];
+
     if (chartInstanceRef.current) {
       chartInstanceRef.current.data.datasets[0].data = data;
+      chartInstanceRef.current.data.labels = labels;
       chartInstanceRef.current.update();
       return;
     }
@@ -100,11 +112,11 @@ function AnalyticsDashboard() {
     chartInstanceRef.current = new window.Chart(ctx, {
       type: 'doughnut',
       data: {
-        labels: ['Success', 'Failure'],
+        labels,
         datasets: [
           {
             data,
-            backgroundColor: ['#36A2EB', '#FF6384'],
+            backgroundColor: ['#36A2EB', '#FF6384', '#FFCE56'],
           },
         ],
       },


### PR DESCRIPTION
## Summary
- track mission failure reasons on backend and include counts in org analytics
- display success vs battery and damage failures in analytics dashboard chart

## Testing
- `npm test`
- `cd Backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897a2572e288324ba3319c77e377d26