### PR TITLE
Add mission data collection parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+npm-debug.log*

--- a/Backend/src/routes/reports.js
+++ b/Backend/src/routes/reports.js
@@ -21,37 +21,41 @@ router.get('/missions/:id', (req, res) => {
     return res.status(404).json({ error: 'Report not found' });
   }
 
-  if (report) {
-    const summary = {
-      mission_id: report.mission_id,
-      duration: report.duration,
-      distance: report.distance,
-      // If the mission has been purged fall back to the coverage value stored in
-      // the report itself.
-      waypoints: mission ? mission.waypoints.length : report.coverage,
-      created_at: report.created_at,
-      start_time: report.start_time,
-      end_time: report.end_time
-    };
-    return res.json(summary);
-  }
+    if (report) {
+      const summary = {
+        mission_id: report.mission_id,
+        duration: report.duration,
+        distance: report.distance,
+        // If the mission has been purged fall back to the coverage value stored in
+        // the report itself.
+        waypoints: mission ? mission.waypoints.length : report.coverage,
+        created_at: report.created_at,
+        start_time: report.start_time,
+        end_time: report.end_time,
+        data_frequency: mission ? mission.dataFrequency : report.data_frequency,
+        sensors: mission ? mission.sensors : report.sensors || []
+      };
+      return res.json(summary);
+    }
 
   // If there's no report yet, expose whatever mission data we have. This is
   // especially useful for missions that are planned or in progress.
-  const summary = {
-    mission_id: mission.id,
-    duration:
-      mission.startTime && mission.endTime
-        ? (mission.endTime - mission.startTime) / 1000
-        : null,
-    distance: mission.totalDistance || mission.distanceTraveled || 0,
-    waypoints: mission.waypoints ? mission.waypoints.length : 0,
-    created_at: null,
-    start_time: mission.startTime ? new Date(mission.startTime).toISOString() : null,
-    end_time: mission.endTime ? new Date(mission.endTime).toISOString() : null
-  };
-  res.json(summary);
-});
+    const summary = {
+      mission_id: mission.id,
+      duration:
+        mission.startTime && mission.endTime
+          ? (mission.endTime - mission.startTime) / 1000
+          : null,
+      distance: mission.totalDistance || mission.distanceTraveled || 0,
+      waypoints: mission.waypoints ? mission.waypoints.length : 0,
+      created_at: null,
+      start_time: mission.startTime ? new Date(mission.startTime).toISOString() : null,
+      end_time: mission.endTime ? new Date(mission.endTime).toISOString() : null,
+      data_frequency: mission.dataFrequency,
+      sensors: mission.sensors || []
+    };
+    res.json(summary);
+  });
 
 // Org-wide analytics
 router.get('/org', (_req, res) => {

--- a/README.md
+++ b/README.md
@@ -18,4 +18,11 @@ This project handles mission management and reporting aspects of drone operation
 - Supports advanced mission patterns such as crosshatch and perimeter.
 - Allows mission-specific parameters like flight altitude and overlap percentage for comprehensive coverage.
 
+## API Notes
+### Mission Creation
+`POST /missions` accepts the following fields:
+- `orgId`, `name`, `area` (GeoJSON Polygon), `altitude`, `pattern`, `overlap`
+- `dataFrequency` &ndash; data collection frequency in hertz
+- `sensors` &ndash; optional array of sensor identifiers to activate during the mission
+
 At FlytBase, we prioritize high-quality, reliable features over superficial coverage. Focus on thoughtful design and engineering to deliver well-crafted solutions.

--- a/frontend/src/AnalyticsDashboard.js
+++ b/frontend/src/AnalyticsDashboard.js
@@ -111,6 +111,15 @@ function AnalyticsDashboard() {
             <li>Duration: {missionSummary.duration}s</li>
             <li>Distance: {missionSummary.distance.toFixed(2)}m</li>
             <li>Waypoints: {missionSummary.waypoints}</li>
+            <li>
+              Data Frequency: {missionSummary.data_frequency}Hz
+            </li>
+            <li>
+              Sensors:{' '}
+              {Array.isArray(missionSummary.sensors)
+                ? missionSummary.sensors.join(', ')
+                : 'N/A'}
+            </li>
           </ul>
         )}
       </div>


### PR DESCRIPTION
## Summary
- allow missions to specify `dataFrequency` and `sensors`
- include data collection parameters in generated reports and analytics dashboard
- document mission creation API and add repo `.gitignore`

## Testing
- `npm test` (backend)
- `CI=true npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68984331ee5483248df7eecc83c9fe5a