### PR TITLE
Fix missions route validation

### DIFF
--- a/Backend/src/routes/missions.js
+++ b/Backend/src/routes/missions.js
@@ -38,11 +38,7 @@ function createMissionsRouter(io) {
       sensors
     } = req.body;
 
-
     if (!orgId || !name || !area || !altitude || !pattern) {
-
-    if (!orgId || !name || !area || !altitude || !pattern || !dataFrequency) {
-
       return res.status(400).json({ error: 'Missing required fields' });
     }
     if (
@@ -56,9 +52,6 @@ function createMissionsRouter(io) {
       dataFrequency !== undefined &&
       (typeof dataFrequency !== 'number' || dataFrequency <= 0)
     ) {
-
-    if (typeof dataFrequency !== 'number' || dataFrequency <= 0) {
-
       return res
         .status(400)
         .json({ error: 'dataFrequency must be a positive number' });
@@ -91,11 +84,7 @@ function createMissionsRouter(io) {
       altitude,
       pattern,
       overlap,
-
       dataFrequency: dataFrequency || 1,
-
-      dataFrequency,
-
       sensors: sensors || [],
       status: 'planned',
       waypoints,


### PR DESCRIPTION
## Summary
- remove duplicate validation blocks in mission creation route
- ensure `dataFrequency` is validated and defaulted correctly

## Testing
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6898476146008324a2eede022a27faf7