### PR TITLE
Use mission data to calculate distance and expose sensor names

### DIFF
--- a/Backend/src/routes/reports.js
+++ b/Backend/src/routes/reports.js
@@ -22,10 +22,17 @@ router.get('/missions/:id', (req, res) => {
   }
 
     if (report) {
+      const sensorList = mission ? mission.sensors : report.sensors || [];
+      const distance =
+        report.distance && report.distance > 0
+          ? report.distance
+          : mission
+          ? mission.distanceTraveled || mission.totalDistance || 0
+          : 0;
       const summary = {
         mission_id: report.mission_id,
         duration: report.duration,
-        distance: report.distance,
+        distance,
         // If the mission has been purged fall back to the coverage value stored in
         // the report itself.
         waypoints: mission ? mission.waypoints.length : report.coverage,
@@ -33,26 +40,27 @@ router.get('/missions/:id', (req, res) => {
         start_time: report.start_time,
         end_time: report.end_time,
         data_frequency: mission ? mission.dataFrequency : report.data_frequency,
-        sensors: mission ? mission.sensors : report.sensors || []
+        sensors: sensorList.map(s => s.name || s)
       };
       return res.json(summary);
     }
 
   // If there's no report yet, expose whatever mission data we have. This is
   // especially useful for missions that are planned or in progress.
+    const sensorList = mission.sensors || [];
     const summary = {
       mission_id: mission.id,
       duration:
         mission.startTime && mission.endTime
           ? (mission.endTime - mission.startTime) / 1000
           : null,
-      distance: mission.totalDistance || mission.distanceTraveled || 0,
+      distance: mission.distanceTraveled || mission.totalDistance || 0,
       waypoints: mission.waypoints ? mission.waypoints.length : 0,
       created_at: null,
       start_time: mission.startTime ? new Date(mission.startTime).toISOString() : null,
       end_time: mission.endTime ? new Date(mission.endTime).toISOString() : null,
       data_frequency: mission.dataFrequency,
-      sensors: mission.sensors || []
+      sensors: sensorList.map(s => s.name || s)
     };
     res.json(summary);
   });

--- a/frontend/src/AnalyticsDashboard.js
+++ b/frontend/src/AnalyticsDashboard.js
@@ -117,7 +117,10 @@ function AnalyticsDashboard() {
             <li>
               Sensors:{' '}
               {Array.isArray(missionSummary.sensors)
-                ? missionSummary.sensors.join(', ')
+                ? missionSummary.sensors
+                    .map((s) => (typeof s === 'string' ? s : s.name || ''))
+                    .filter(Boolean)
+                    .join(', ')
                 : 'N/A'}
             </li>
           </ul>


### PR DESCRIPTION
## Summary
- compute mission distance from available mission data when report distance is missing
- normalize sensors to names and render them in the analytics dashboard

## Testing
- `npm test` (backend)
- `CI=true npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6898507f38a88324a20f04ec35735f88